### PR TITLE
fix bug WDP210501-65

### DIFF
--- a/src/components/features/NewFurniture/NewFurniture.js
+++ b/src/components/features/NewFurniture/NewFurniture.js
@@ -5,7 +5,7 @@ import ProductBox from '../../common/ProductBox/ProductBox';
 import { SIZE_TYPES } from '../../../settings';
 import CompareBox from '../CompareBox/CompareBoxContainer.js';
 import Swipeable from '../../common/Swipeable/Swipeable';
-
+import { Link } from 'react-router-dom';
 class NewFurniture extends React.Component {
   state = {
     activePage: 0,
@@ -146,8 +146,8 @@ class NewFurniture extends React.Component {
                   <ul>
                     {categories.map(item => (
                       <li key={item.id}>
-                        <a
-                          href='/#'
+                        <Link
+                          to='/#'
                           className={
                             item.id === activeCategory ? styles.active : undefined
                           }
@@ -156,7 +156,7 @@ class NewFurniture extends React.Component {
                           }}
                         >
                           {item.name}
-                        </a>
+                        </Link>
                       </li>
                     ))}
                   </ul>


### PR DESCRIPTION
Obecnie po kliknięciu w dowolną kategorię w sekcji New Furniture na stronie głównej okno przeskakuje na samą górę strony, co jest uciążliwe.

AC:
1. Po kliknięciu w dowolną kategorię w sekcji New Furniture na stronie głównej pozycja okna pozostaje bez zmian.

